### PR TITLE
Remove python-imaging from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ But first you'll need some dependencies:
 
 ```
 sudo apt-get update
-sudo apt-get install python-rpi.gpio python-spidev python-pip python-imaging python-numpy
+sudo apt-get install python-rpi.gpio python-spidev python-pip python-numpy
 ```
 
 And then you'll need the st7789 library:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ But first you'll need some dependencies:
 
 ```
 sudo apt-get update
-sudo apt-get install python-rpi.gpio python-spidev python-pip python-numpy
+sudo apt-get install python-rpi.gpio python-spidev python-pip python-pil python-numpy
 ```
 
 And then you'll need the st7789 library:

--- a/mopidy/README.md
+++ b/mopidy/README.md
@@ -38,7 +38,7 @@ Next, update apt and install the necessary dependencies:
 
 ```
 sudo apt update
-sudo apt-get install python-rpi.gpio python-spidev python-pip python-imaging python-numpy
+sudo apt-get install python-rpi.gpio python-spidev python-pip python-pil python-numpy
 ```
 
 ### Mopidy with Spotify and Iris


### PR DESCRIPTION
`python-imaging` isn't installed by [install.sh](https://github.com/pimoroni/pirate-audio/blob/master/mopidy/install.sh#L45) so presumably isn't needed. It's also not available to install:

> Package python-imaging is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python-pil