### PR TITLE
Lock Install to Python 2.x

### DIFF
--- a/mopidy/install.sh
+++ b/mopidy/install.sh
@@ -65,6 +65,7 @@ RESULT=$?
 if [ "$RESULT" == "0" ]; then
   inform "Stopping Mopidy service..."
   systemctl stop mopidy
+  echo
 fi
 
 # Enable SPI

--- a/mopidy/install.sh
+++ b/mopidy/install.sh
@@ -78,6 +78,7 @@ if [ -f "$MOPIDY_CONFIG" ]; then
   inform "Backing up mopidy config to: $MOPIDY_CONFIG.backup-$DATESTAMP"
   cp "$MOPIDY_CONFIG" "$MOPIDY_CONFIG.backup-$DATESTAMP"
   EXISTING_CONFIG=true
+  echo
 fi
 
 # Install apt list for Mopidy, see: https://docs.mopidy.com/en/latest/installation/debian/.


### PR DESCRIPTION
Temporarily lock down apt install of mopidy and mopidy-spotify to version that support python 2.x
Add python/pip check to verify that pip exists and is from python 2.x