### PR TITLE
Add Speaker/Mic combo instructions

### DIFF
--- a/speaker-and-mic/.gitignore
+++ b/speaker-and-mic/.gitignore
@@ -1,0 +1,1 @@
+adau7002-pcm5102a-io.dtbo

--- a/speaker-and-mic/Makefile
+++ b/speaker-and-mic/Makefile
@@ -1,0 +1,5 @@
+dtoverlay:
+	dtc -I dts -O dtb -o adau7002-pcm5102a-io.dtbo adau7002-pcm5102a-io-overlay.dts
+
+install: dtoverlay
+	cp adau7002-pcm5102a-io.dtbo /boot/overlays

--- a/speaker-and-mic/README.md
+++ b/speaker-and-mic/README.md
@@ -1,0 +1,73 @@
+# Speaker & Dual Mic HAT Combined
+
+The following dtoverlay and instructions will help you use a speaker/audio output HAT (specifically one that uses pcm5012a) alongside Dual Mic HAT (adau7002).
+
+## Installing
+
+Build the .dtbo file with `make` and then copy it to `/boot/overlays` or run `sudo make install`.
+
+Add the following to `/boot/config.txt`:
+
+```
+dtoverlay=adau7002-pcm5102a-io
+```
+
+Add the following into `~/.asound.conf` or `/etc/asound.conf` as per the clip recorder README: https://github.com/pimoroni/pirate-audio/tree/master/clip-recorder
+
+```
+pcm.mic_hw{
+    type hw
+    card adau7002
+    format S32_LE
+    rate 48000
+    channels 2
+}
+pcm.mic_rt{
+    type route
+    slave.pcm mic_hw
+    ttable.0.0 1
+    ttable.0.1 0
+    ttable.1.0 0
+    ttable.1.1 1
+}
+pcm.mic_plug {
+    type plug
+    slave.pcm mic_rt
+}
+pcm.mic_filter {
+    type ladspa
+    slave.pcm mic_plug
+    path "/usr/lib/ladspa";
+    plugins [
+    {
+        label invada_hp_stereo_filter_module_0_1
+        input {
+	    controls [
+                50   # Cut off frequency (Hz)
+                30   # Gain (dB)
+                1    # Soft Clip (on/off)
+            ]
+	}
+    }
+    ]
+}
+pcm.mic_out {
+    type plug
+    slave.pcm mic_filter
+}
+```
+
+Test the speaker with:
+
+```
+speaker-test -c2 -twav -l2
+```
+
+Try a test recording:
+
+```
+arecord -D hw:adau7002,1 -c2 -r48000 -fS32_LE -twav -d5 -R10000 -Vstereo test.wav
+```
+
+
+Thanks to Don - https://forums.pimoroni.com/t/small-speaker-dual-mic-hats-at-the-same-time/18083/7 - for verifying this!

--- a/speaker-and-mic/adau7002-pcm5102a-io-overlay.dts
+++ b/speaker-and-mic/adau7002-pcm5102a-io-overlay.dts
@@ -1,0 +1,77 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "brcm,bcm2835";
+
+    fragment@0 {
+        target = <&i2s>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+
+    fragment@1 {
+        target-path = "/";
+        __overlay__ {
+            pcm5102a_codec: pcm5102a-codec {
+                #sound-dai-cells = <0>;
+                compatible = "ti,pcm5102a";
+                status = "okay";
+            };
+        };
+    };
+
+    fragment@2 {
+        target-path = "/";
+        __overlay__ {
+                adau7002_codec: adau7002-codec {
+                #sound-dai-cells = <0>;
+                compatible = "adi,adau7002";
+/*                IOVDD-supply = <&supply>;*/
+                status = "okay";
+            };
+        };
+    };
+
+    fragment@3 {
+        target = <&sound>;
+            sound_overlay: __overlay__ {
+            compatible = "simple-audio-card";
+            simple-audio-card,format = "i2s";
+            simple-audio-card,name = "adau7002";
+            simple-audio-card,bitclock-slave = <&dailink1>;
+            simple-audio-card,frame-slave = <&dailink1>;
+            simple-audio-card,widgets =
+                    "Microphone", "Microphone Jack";
+            simple-audio-card,routing =
+                    "PDM_DAT", "Microphone Jack";
+            status = "okay";
+            dailink0: simple-audio-card,dai-link@0 {
+                reg = <0>;
+                format = "i2s";
+                cpu {
+                    sound-dai = <&i2s>;
+                };
+                codec {
+                    sound-dai = <&adau7002_codec>;
+                };
+            };
+            dailink1: simple-audio-card,dai-link@1 {
+                reg = <0>;
+                format = "i2s";
+                cpu {
+                    sound-dai = <&i2s>;
+                };
+                codec {
+                    sound-dai = <&pcm5102a_codec>;
+                };
+            };
+        };
+    };
+
+
+    __overrides__ {
+        card-name = <&sound_overlay>,"simple-audio-card,name";
+    };
+};

--- a/speaker-and-mic/asound.conf
+++ b/speaker-and-mic/asound.conf
@@ -1,0 +1,41 @@
+pcm.mic_hw{
+    type hw
+    card adau7002
+    format S32_LE
+    rate 48000
+    channels 2
+}
+pcm.mic_rt{
+    type route
+    slave.pcm mic_hw
+    ttable.0.0 1
+    ttable.0.1 0
+    ttable.1.0 0
+    ttable.1.1 1
+}
+pcm.mic_plug {
+    type plug
+    slave.pcm mic_rt
+}
+pcm.mic_filter {
+    type ladspa
+    slave.pcm mic_plug
+    path "/usr/lib/ladspa";
+    plugins [
+    {
+        label invada_hp_stereo_filter_module_0_1
+        input {
+	    controls [
+                50   # Cut off frequency (Hz)
+                30   # Gain (dB)
+                1    # Soft Clip (on/off)
+            ]
+	}
+    }
+    ]
+}
+pcm.mic_out {
+    type plug
+    slave.pcm mic_filter
+}
+


### PR DESCRIPTION
As discussed on the forums here - https://forums.pimoroni.com/t/small-speaker-dual-mic-hats-at-the-same-time/18083/7 - this changeset adds a dtoverlay and instructions for running both the speaker and microphone simultaneously using simple-audio-card.