### PR TITLE
Update Mopidy installer’s apt list destination

### DIFF
--- a/mopidy/install.sh
+++ b/mopidy/install.sh
@@ -82,10 +82,10 @@ fi
 # Install apt list for Mopidy, see: https://docs.mopidy.com/en/latest/installation/debian/.
 if [ ! -f "/etc/apt/sources.list.d/mopidy.list" ]; then
   inform "Adding Mopidy apt source"
-  mkdir -p /usr/local/share/keyrings
-  wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg \
+  mkdir -p /etc/apt/keyrings
+  wget -q -O /etc/keyrings/mopidy-archive-keyring.gpg \
     https://apt.mopidy.com/mopidy.gpg
-  wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list
+  wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/bullseye.list
   apt update
   echo
 fi


### PR DESCRIPTION
_Tested on a Raspberry Pi Zero v1.1 running Raspberry Pi OS Lite._

While running `mopidy/install.sh` on a fresh install of Raspberry Pi OS, I saw the following error:

```
E: Unable to locate package mopidy-spotify
```

Looking into it further, it seems Mopidy have recently updated their installation docs to [use `/etc/apt/keyrings`](https://github.com/mopidy/mopidy/commit/c7b310a631fb37ada6b5d1154e3c1fd427e479e2), and to [switch from Buster to Bullseye as the minimum Debian distribution](https://github.com/mopidy/mopidy/commit/890d8f1f437b79fec41a1779eb81ed5b93f4fe74).

This commit updates `install.sh` to align with the current installation instructions for Mopidy.