### PR TITLE
Add experimental Spotify install.

### DIFF
--- a/mopidy/README.md
+++ b/mopidy/README.md
@@ -1,5 +1,6 @@
 # Pirate Audio Mopidy Setup
 
+:warning: Spotify support has been in turmoil for a while, and these instructions install mopidy-spotify from git, expect bugs until there is a stable release. See: https://github.com/mopidy/mopidy-spotify/issues/110
 
 ## Automatic Setup
 
@@ -46,8 +47,8 @@ sudo apt-get install python3-rpi.gpio python3-spidev python3-pip python3-pil pyt
 You can now install Mopidy. Both `mopidy-spotify` and `mopidy-iris` are optional. The former adds support for the music streaming service of the same name, and `iris` is a web interface for Mopidy that you'll no doubt find useful.
 
 ```
-sudo apt install mopidy mopidy-spotify
-sudo pip3 install mopidy-iris
+sudo python3 -m pip install git+https://github.com/mopidy/mopidy-spotify
+sudo python3 -m pip install mopidy-iris
 ```
 
 Iris uses a shell script to perform actions such as restarting Mopidy and scanning for local files (https://github.com/jaedb/Iris/blob/master/mopidy_iris/system.sh), it needs root privileges to do this which can be granted with sudoers like so (assuming your Python is version 3.7, you can find the dist-packages dir with `python3 -m site`):

--- a/mopidy/install.sh
+++ b/mopidy/install.sh
@@ -91,9 +91,14 @@ if [ ! -f "/etc/apt/sources.list.d/mopidy.list" ]; then
 fi
 
 # Install Mopidy and core plugins for Spotify
-inform "Installing mopidy packages"
-apt-mark unhold mopidy mopidy-spotify
-apt install -y mopidy mopidy-spotify
+inform "Installing Mopidy packages"
+apt-mark unhold mopidy
+apt install -y mopidy
+echo
+
+
+inform "Insyalling Mopidy Spotify from GitHub"
+$PIP_BIN install --upgrade git+https://github.com/mopidy/mopidy-spotify
 echo
 
 # Install Mopidy Iris web UI
@@ -130,7 +135,7 @@ echo
 if [ $EXISTING_CONFIG ]; then
   warning "Resetting $MOPIDY_CONFIG to package defaults."
   inform "Any custom settings have been backed up to $MOPIDY_CONFIG.backup-$DATESTAMP"
-  apt install --reinstall -o Dpkg::Options::="--force-confask,confnew,confmiss" mopidy=$MOPIDY_VERSION > /dev/null 2>&1
+  apt install --reinstall -o Dpkg::Options::="--force-confask,confnew,confmiss" mopidy > /dev/null 2>&1
   echo
 fi
 
@@ -138,6 +143,7 @@ fi
 # Updated to only change necessary values, as per: https://github.com/pimoroni/pirate-audio/issues/1
 # Updated to *append* config values to mopidy.conf, as per: https://github.com/pimoroni/pirate-audio/issues/1#issuecomment-557556802
 inform "Configuring Mopidy"
+
 cat <<EOF >> $MOPIDY_CONFIG
 
 [raspberry-gpio]


### PR DESCRIPTION
This installs Spotify from Git. Also fixes an issue with the Mopidy config not resetting to default.