### PR TITLE
Update install.sh to test for bookworm firmware location

### DIFF
--- a/mopidy/install.sh
+++ b/mopidy/install.sh
@@ -6,6 +6,7 @@ MOPIDY_SUDOERS="/etc/sudoers.d/010_mopidy-nopasswd"
 EXISTING_CONFIG=false
 PYTHON_MAJOR_VERSION=3
 PIP_BIN=pip3
+RPI_CONFIG="/boot/config.txt"
 
 function add_to_config_text {
     CONFIG_LINE="$1"
@@ -69,8 +70,9 @@ fi
 raspi-config nonint do_spi 0
 
 # Add necessary lines to config.txt (if they don't exist)
-add_to_config_text "gpio=25=op,dh" /boot/config.txt
-add_to_config_text "dtoverlay=hifiberry-dac" /boot/config.txt
+[ -f /boot/firmware/config.txt ] && RPI_CONFIG=/boot/firmware/config.txt
+add_to_config_text "gpio=25=op,dh" "$RPI_CONFIG"
+add_to_config_text "dtoverlay=hifiberry-dac" "$RPI_CONFIG"
 
 if [ -f "$MOPIDY_CONFIG" ]; then
   inform "Backing up mopidy config to: $MOPIDY_CONFIG.backup-$DATESTAMP"


### PR DESCRIPTION
Raspberry Pi OS Bookworm (12) updated the location of the firmware configuration from /boot/config.txt to /boot/firmware/config.txt. The install script needs to detect whether the new file exists, and if so, change the path of the file to modify. I didn't test this, but it looks right.